### PR TITLE
Contract testing example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,13 @@
 		</dependency>
 		<!-- /end -->
 
+		<!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-test -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/bumpsh/demo/EmployeeNotFoundAdvice.java
+++ b/src/main/java/com/bumpsh/demo/EmployeeNotFoundAdvice.java
@@ -5,12 +5,14 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+record ErrorResponse(String message) {}
+
 @RestControllerAdvice
 class EmployeeNotFoundAdvice {
 
 	@ExceptionHandler(EmployeeNotFoundException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)
-	String employeeNotFoundHandler(EmployeeNotFoundException ex) {
-		return ex.getMessage();
+	ErrorResponse employeeNotFoundHandler(EmployeeNotFoundException ex) {
+		return new ErrorResponse(ex.getMessage());
 	}
 }

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -21,6 +21,27 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/Employee"
+      responses:
+        '201':
+          description: 'successfully created'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Employee"
+  /employees/{id}:
+    get:
+      description: get employee list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Employee"
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundResponseBody"
 components:
   schemas:
     Employee:
@@ -32,4 +53,14 @@ components:
         name:
           type: string
         role:
+          type: string
+    NotFoundResponseBody:
+      type: object
+      required:
+        - id
+        - message
+      properties:
+        id:
+          type: integer
+        message:
           type: string

--- a/src/test/java/com/bumpsh/demo/EmployeeApiTest.java
+++ b/src/test/java/com/bumpsh/demo/EmployeeApiTest.java
@@ -1,0 +1,64 @@
+package com.bumpsh.demo;
+
+import com.github.erosb.kappa.autoconfigure.EnableKappaContractTesting;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The @EnableKappaContractTesting will tell Kappa to validate all HTTP requests and responses against the openapi.yaml.
+ *
+ * So contract testing is an additional verification step in every test. If an endpoint sends a response that doesn't
+ * match the openapi description, then the test will fail, even if all assertions of the concrete test would pass.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@EnableKappaContractTesting
+@Tag("failing-contract-tests")
+public class EmployeeApiTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    /**
+     * Fails because the openapi.yaml describes a HTTP 201 Created response code, but the SUT responds with 200 OK.
+     */
+    @Test
+    void responseCodeMismatch() throws Exception {
+        mvc.perform(post("/employees").contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                            "name": "Bilbo",
+                            "role": "ring-bearer"
+                        }
+                        """))
+                // here we don't exactly specify the expected response code
+                // but due to @EnableKappaContractTesting, Kappa will still check if the response code is in the openapi.yaml
+                .andExpect(status().is2xxSuccessful());
+    }
+
+    /**
+     * Fails because the 404 response in the openapi.yaml describes a mandatory "id" property, but it isn't present in the response
+     */
+    @Test
+    void notFoundResponseBodyMismatch() throws Exception {
+        mvc.perform(MockMvcRequestBuilders.get("/employees/22").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                // actually, this is the json that will be returned by the endpoint, but it doesn't match the openapi description
+                // due to the missing "id" property, so the test fails
+                .andExpect(content().json("""
+                        {
+                            "message": "Could not find employee 22"
+                        }
+                        """));
+    }
+}


### PR DESCRIPTION
This test is a pretty standard spring MockMvc test, with an additional `@EnableKappaContractTesting` annotation. This will tell Kappa to validate all requests and responses against the openapi.yaml description, and make the tests fail on mismatch.

So `@EnableKappaContractTesting` is a sort of a counterpart of `@EnableKappaRequestValidation`. And this is also an undocumented feature currently :)

edit: with this change, the maven build will (obvoiusly) fail because of the added failing tests. You can skip the tests by passing `mvn clean package -Dgroups='!failing-contract-tests'`