### PR TITLE
Add a custom ValidationFailureSender which sends an RFC9457-compliant response to the client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>com.github.erosb</groupId>
 			<artifactId>kappa-spring</artifactId>
-			<version>2.0.0-RC14.3</version>
+			<version>2.0.0-RC15</version>
 		</dependency>
 		<!-- /end -->
 

--- a/src/main/java/com/bumpsh/demo/DemoApplication.java
+++ b/src/main/java/com/bumpsh/demo/DemoApplication.java
@@ -1,28 +1,87 @@
 package com.bumpsh.demo;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.erosb.kappa.autoconfigure.EnableKappaRequestValidation;
 import com.github.erosb.kappa.autoconfigure.KappaSpringConfiguration;
+import com.github.erosb.kappa.core.validation.OpenApiValidationFailure;
+import com.github.erosb.kappa.core.validation.ValidationException;
+import com.github.erosb.kappa.operation.validator.adapters.server.servlet.ValidationFailureSender;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
+
+import static java.util.Objects.requireNonNull;
 
 @SpringBootApplication
 @EnableKappaRequestValidation
 public class DemoApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DemoApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
 
-	@Bean
-	public KappaSpringConfiguration kappaSpringConfiguration() {
-		KappaSpringConfiguration kappaConfig = new KappaSpringConfiguration();
-		var pathPatternToOpenapiDescription = new LinkedHashMap<String, String>();
-		pathPatternToOpenapiDescription.put("/**", "/api/openapi.yaml");
-		kappaConfig.setOpenapiDescriptions(pathPatternToOpenapiDescription);
-		return kappaConfig;
-	}
+    @Bean
+    public KappaSpringConfiguration kappaSpringConfiguration() {
+        KappaSpringConfiguration kappaConfig = new KappaSpringConfiguration();
+        var pathPatternToOpenapiDescription = new LinkedHashMap<String, String>();
+        pathPatternToOpenapiDescription.put("/**", "/api/openapi.yaml");
+        kappaConfig.setOpenapiDescriptions(pathPatternToOpenapiDescription);
+        kappaConfig.setValidationFailureSender(new RFC9457FailureSender());
+        return kappaConfig;
+    }
 
+}
+
+class RFC9457FailureSender
+        implements ValidationFailureSender {
+
+    private final String typeAttributeValue;
+
+    public RFC9457FailureSender() {
+        this("https://erosb.github.io/kappa/request-validation-failure");
+    }
+
+    public RFC9457FailureSender(String typeAttributeValue) {
+        this.typeAttributeValue = requireNonNull(typeAttributeValue);
+    }
+
+    @Override
+    public void send(ValidationException ex, HttpServletResponse httpResp)
+            throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode respObj = objectMapper.createObjectNode();
+        ArrayNode errors = objectMapper.createArrayNode();
+        respObj.put("type", typeAttributeValue);
+        respObj.put("status", 400);
+        respObj.put("title", "Validation failure");
+        respObj.put("detail", ex.getMessage());
+        ex.results().forEach(item -> {
+            ObjectNode error = objectMapper.createObjectNode();
+            error.put("message", item.getMessage());
+            error.put("dataLocation", item.describeInstanceLocation());
+            String schemaLocation = item.describeSchemaLocation();
+            int openapiDirIndex = schemaLocation.lastIndexOf("openapi/");
+            if (openapiDirIndex >= 0) {
+                error.put("schemaLocation", schemaLocation.substring(openapiDirIndex));
+            } else {
+                error.put("schemaLocation", schemaLocation);
+            }
+            if (item instanceof OpenApiValidationFailure.SchemaValidationFailure) {
+                OpenApiValidationFailure.SchemaValidationFailure schemaValidationFailure = (OpenApiValidationFailure.SchemaValidationFailure) item;
+                error.put("dynamicPath", schemaValidationFailure.getFailure().getDynamicPath().getPointer().toString());
+            }
+            errors.add(error);
+        });
+        respObj.put("errors", errors);
+
+        httpResp.setStatus(400);
+        httpResp.getWriter().print(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(respObj));
+        httpResp.flushBuffer();
+    }
 }

--- a/src/main/java/com/bumpsh/demo/EmployeeNotFoundAdvice.java
+++ b/src/main/java/com/bumpsh/demo/EmployeeNotFoundAdvice.java
@@ -12,7 +12,7 @@ class EmployeeNotFoundAdvice {
 
 	@ExceptionHandler(EmployeeNotFoundException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)
-	ErrorResponse employeeNotFoundHandler(EmployeeNotFoundException ex) {
-		return new ErrorResponse(ex.getMessage());
+	Object employeeNotFoundHandler(EmployeeNotFoundException ex) {
+		return ex.getMessage(); // new ErrorResponse(ex.getMessage());
 	}
 }


### PR DESCRIPTION
Attempt to add an RFC9457-compliant validation failure sender (follow-up of a recent Kappa-side improvement to let users customize their failure format, released in kappa-spring-2.0.0-RC15). This `ValidationFailureSender` implementation can be either part of this example project, but it can also be the default behavior of Kappa itself.

Example response sent by the `DemoApplication` with the failure sender implemented in this PR:

```json
{
  "type" : "https://erosb.github.io/kappa/validation-failure",
  "status" : 400,
  "title" : "Validation failure",
  "detail" : "Invalid request.",
  "errors" : [ {
    "message" : "false schema always fails",
    "dataLocation" : "$request.body#/nam (line 1, position 23)",
    "schemaLocation" : "file:/home/erosb/projects/spring-design-first/target/classes/api/openapi.yaml#/components/schemas/Employee/additionalProperties",
    "dynamicPath" : "#/$ref/additionalProperties/false"
  } ]
}
```