### PR TITLE
replace */* with application/json; also change POST response status code to 201 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>com.github.erosb</groupId>
 			<artifactId>kappa-spring</artifactId>
-			<version>2.0.0-RC15</version>
+			<version>2.0.0-RC16</version>
 		</dependency>
 		<!-- /end -->
 

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -33,7 +33,7 @@ paths:
         '404':
           description: Not Found
           content:
-            '*/*':
+            'application/json':
               schema:
                 type: string
       tags:
@@ -59,13 +59,13 @@ paths:
         '200':
           description: OK
           content:
-            '*/*':
+            'application/json':
               schema:
                 $ref: '#/components/schemas/Employee'
         '404':
           description: Not Found
           content:
-            '*/*':
+            'application/json':
               schema:
                 type: string
       tags:
@@ -87,7 +87,7 @@ paths:
         '404':
           description: Not Found
           content:
-            '*/*':
+            'application/json':
               schema:
                 type: string
       tags:
@@ -101,7 +101,7 @@ paths:
         '200':
           description: OK
           content:
-            '*/*':
+            'application/json':
               schema:
                 type: array
                 items:
@@ -109,7 +109,7 @@ paths:
         '404':
           description: Not Found
           content:
-            '*/*':
+            'application/json':
               schema:
                 type: string
       tags:
@@ -125,16 +125,16 @@ paths:
             schema:
               $ref: '#/components/schemas/Employee'
       responses:
-        '200':
+        '201':
           description: OK
           content:
-            '*/*':
+            'application/json':
               schema:
                 $ref: '#/components/schemas/Employee'
         '404':
           description: Not Found
           content:
-            '*/*':
+            'application/json':
               schema:
                 type: string
       tags:


### PR DESCRIPTION
## Changes

 * changes `*/*` content type definitions to `application/json` ([discussed here](https://github.com/bump-sh/docs/pull/381#discussion_r2225881836))
 * also `EmployeeApiTest.responseCodeMismatch()` was passing. The point of this test is to demo that the test fails if an unexpected response code is returned from the API. Now this is restored by changing the POST response status code to 201 in `openapi.yaml` , now the test fails as it should.